### PR TITLE
bumped the allure-framework release to 2.17.2 and added selective test run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ There is another way of generating the report. The generated report can be opene
 $ ./mvnw io.qameta.allure:allure-maven:report
 ```
 
+### Tests selective run (filtering)
+
+This feature works when you are triggering a build from Allure TestOps by selecting seperate test cases (not all in your project).
+
+Allure TestOps agent creates **testplan.json** file  with the list of tests on CI, then the test framework adaptor reads the content and makes the seletion of the tests to be executed.
+
+#### Requirements
+
+Allure framework libraries not earlier than 2.13.9
+
+#### How to check locally
+
+For this particular exapmple we have **testplan.json** with the following content:
+
+```JSON
+{ "version": "1.0", "tests": [{ "id": 11111, "selector": "my.company.SimpleTest.simpleTestOne" }] }
+```
+So, we expect only `simpleTestOne` test to be executed.
+
+##### Steps
+
+In the terminal type the following:
+```bash
+export ALLURE_TESTPLAN_PATH=testplan.json
+# just to check the variable was created 
+echo $ALLURE_TESTPLAN_PATH
+./mvnw clean test
+```
+
+TestNG will execute only one test of the two tests present in this example project.
+
+
+
 ### More
 
 * [Documentation](https://docs.qameta.io/allure/2.0/)

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <allure.version>2.13.2</allure.version>
+        <allure.version>2.17.2</allure.version>
         <java.version>1.8</java.version>
         <aspectj.version>1.9.5</aspectj.version>
     </properties>

--- a/src/test/java/my/company/SimpleTest.java
+++ b/src/test/java/my/company/SimpleTest.java
@@ -10,7 +10,12 @@ import static io.qameta.allure.Allure.step;
 public class SimpleTest {
 
     @Test
-    public void simpleTest() {
+    public void simpleTestOne() {
+        step("step 1");
+        step("step 2");
+    }
+    @Test
+    public void simpleTestTwo() {
         step("step 1");
         step("step 2");
     }

--- a/testplan.json
+++ b/testplan.json
@@ -1,0 +1,1 @@
+{ "version": "1.0", "tests": [{ "id": 11111, "selector": "my.company.SimpleTest.simpleTestOne" }] }


### PR DESCRIPTION
1. added testplan.json for the demonstration of the filtering
2. added a copy of the initial simple test (otherwise the filtering cannot be demonstrated)
3. updated README.md on how to check the tests filtering